### PR TITLE
add a `template` attribute to Contact

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,31 @@ Finally, each user has a global configuration, limiting how many notifications
 in total can be sent to him during some period of time. If this limit is
 reached, no notification is sent until the limit resets at the next period.
 
+Notification Templates
+----------------------
+Pancake uses notification service to actually send the notifications.
+The content of the notifications is rendered with templates. Each contact
+has a `template` attribute, which is used to determine which templates to use
+when rendering different notifications.
+
+Currently Email and SMS notifications are supported.
+
+For Email notifications, the following templates are used:
+* `%{contact.template}s.subject` renders the subject of the email
+* `%{contact.template}s.html` renders the html content of the email
+* `%{contact.template}s.txt` renders the txt content of the email
+
+For SMS notifications, the template `%{contact.template}s.sms` is used to
+render the content of the SMS.
+
+All those templates but be defined in the notification service beforehand,
+otherwise notifications cannot be sent successfully. The template attribute
+can be set to any string.
+For example, the organization of the user or his name. It depends
+on how much you want to personalize the content of the notifications.
+Of course, the more personalized, the more templates you need to create.
+
+
 Cookbook
 --------
  * Only send notifications according to a pre-defined schedule, i.e., 8 AM. to

--- a/pancake/app.py
+++ b/pancake/app.py
@@ -1,6 +1,7 @@
 import ast
 import logging.config
 import os
+import sys
 from eve import Eve
 from eve_docs import eve_docs
 from eve_mongoengine import EveMongoengine
@@ -81,10 +82,14 @@ def configure_ext(app):
     return app
 
 
-if __name__ == "__main__":
-    import sys
-    if len(sys.argv) == 2:
-        port = int(sys.argv[1])
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    if len(args) == 1:
+        port = int(args[0])
     else:
         port = 8080
     create_app().run(debug=True, port=port)
+
+if __name__ == "__main__":
+    main()

--- a/pancake/models.py
+++ b/pancake/models.py
@@ -50,6 +50,8 @@ class Contact(Document, ResourceMixin):
     """
     Represents an external user. Also bears user notification preference.
     """
+    template = StringField(
+        required=True, help_text="template to use in notifications")
     user_id = StringField(unique=True, required=True,
                           help_text='id of the external user')
     interval = IntField(

--- a/pancake/models.py
+++ b/pancake/models.py
@@ -153,7 +153,7 @@ class Acknowledgement(Document, ResourceMixin):
              write_concern=None,  cascade=None, cascade_kwargs=None,
              _refs=None, **kwargs):
         if not self.end_time:
-            self.end_time = self.start_time + timedelta(days=365000)
+            self.end_time = self.start_time + timedelta(days=36500)
         return super(Acknowledgement, self).save(
             force_insert, validate, clean, write_concern, cascade,
             cascade_kwargs, _refs, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,9 @@ setup(
     },
     zip_safe=False,
     keywords='pancake',
+	entry_points={
+		'console_scripts': [
+			'pancaked = pancake.app:main'
+		]
+	},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,8 @@ def model_factory(request, o):
 @pytest.fixture
 def contact(request):
     return model_factory(request, Contact(
-        user_id=uuid.uuid4().hex, notifications=10, interval=20))
+        user_id=uuid.uuid4().hex, template='dev',
+        notifications=10, interval=20))
 
 
 @pytest.fixture(params=[
@@ -72,6 +73,7 @@ def media_email(request, contact):
     return model_factory(request, Media(
         type='email', address='blurrcat@gmail.com', contact=contact
     ))
+
 
 @pytest.fixture
 def event(request, contact):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ def test_create_contact(app):
         # create contact
         r = c.post('/contact', json={
             'user_id': '1',
+            'template': 'dev.events',
             'interval': 86400,
             'notifications': 1,
         })
@@ -104,6 +105,8 @@ def test_multiple_subscription(app, contact, subscription,
         # 2 subscription with the same subscriber matches
         # shall only send one notification
         assert notification_service.notify_email.call_count == 1
+        assert contact.template in str(
+            notification_service.notify_email.call_args)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use `contact.template` to determine which
templates to use when rendering notifications